### PR TITLE
Java 24 Updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,14 +16,14 @@ jobs:
     if: github.event_name == 'pull_request'
     steps:
       - name: Pull Request Version Validation
-        uses: ikmdev/maven-pull-request-version-validation-action@v2
+        uses: ikmdev/maven-pull-request-version-validation-action@v2.1.0
         
   build-job:
     name: Build Job
     runs-on: ubuntu-24.04
     steps:      
       - name: Build IKMDEV Code
-        uses: ikmdev/maven-clean-install-build-action@v3
+        uses: ikmdev/maven-clean-install-build-action@v3.5.0
         with:
           branch_name: ${{github.ref_name}}
          

--- a/.github/workflows/post_build.yml
+++ b/.github/workflows/post_build.yml
@@ -27,7 +27,7 @@ jobs:
           
       - name: IKMDEV Post Build Action
         id: ikmdev_post_build
-        uses: ikmdev/maven-post-build-action@v3.1.0
+        uses: ikmdev/maven-post-build-action@v3.2.0
         with:
             nexus_repo_password: ${{secrets.EC2_NEXUS_PASSWORD}}
             branch_name: ${{github.event.workflow_run.head_branch}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
           token: ${{secrets.IKMDEVOPS_PAT_TOKEN}}
 
       - name: Shared Release Action
-        uses: ikmdev/maven-semver-release-action@v2
+        uses: ikmdev/maven-semver-release-action@v2.7.0
         with:
           version_type: ${{ github.event.inputs.version_type }}
           github_token: ${{secrets.GITHUB_TOKEN}}

--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,1 +1,0 @@
---enable-preview

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -16,4 +16,4 @@
 # under the License.
 wrapperVersion=3.3.2
 distributionType=only-script
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.11/apache-maven-3.9.11-bin.zip

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Primary changes:
 * Remove some modules, retaining core API and parsers
 * Replace guava with java.util and Eclipse collections
 
+Requirements:
+
 * Requires Java 24.
 * Requires Maven 3.9.11
 * Requires Git

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ Primary changes:
 * Remove some modules, retaining core API and parsers
 * Replace guava with java.util and Eclipse collections
 
-Requires Java 24.
-Requires Maven 3.9.11
-Requires Git
+* Requires Java 24.
+* Requires Maven 3.9.11
+* Requires Git
 
 To build on Unix/Linux/OSX: `./mvnw clean install`
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Primary changes:
 * Replace guava with java.util and Eclipse collections
 
 Requires Java 24.
+Requires Maven 3.9.11
+Requires Git
 
 To build on Unix/Linux/OSX: `./mvnw clean install`
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Primary changes:
 * Remove some modules, retaining core API and parsers
 * Replace guava with java.util and Eclipse collections
 
-Requires Java 21.
+Requires Java 24.
 
 To build on Unix/Linux/OSX: `./mvnw clean install`
 

--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,7 @@
 		<maven-site-plugin.version>3.21.0</maven-site-plugin.version>
 		<maven-source-plugin.version>3.3.1</maven-source-plugin.version>
 		<maven-surefire-plugin.version>3.5.3</maven-surefire-plugin.version>
+		<maven-dependency-analyzer.version>1.16.0</maven-dependency-analyzer.version>
 		<!-- other plugins -->
 		<license-maven-plugin.version>2.6.0</license-maven-plugin.version>
 		<sonatype.central.plugin.version>0.8.0</sonatype.central.plugin.version> <!-- Property for deploying to Maven Central -->
@@ -459,7 +460,15 @@
 						</configuration>
 					</execution>
 				</executions>
-			</plugin>
+				<dependencies>
+					<!-- Necessary for JDK 24. Should be removed for updates of dependency plugin -->
+					<dependency>
+						<groupId>org.apache.maven.shared</groupId>
+						<artifactId>maven-dependency-analyzer</artifactId>
+						<version>${maven-dependency-analyzer.version}</version>
+					</dependency>
+				</dependencies>
+		</plugin>
 			<plugin>
 				<groupId>dev.ikm</groupId>
 				<artifactId>gitflow-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<java.version>21</java.version>
+		<java.version>24</java.version>
 		<java.compilerArgs></java.compilerArgs>
 		<!-- logging dependencies -->
 		<slf4j.version>2.0.17</slf4j.version>


### PR DESCRIPTION
- Updated the GH Actions to us newer released versions
    - build.yaml
        - ikmdev/maven-pull-request-version-validation-action@v2.1.0
        - ikmdev/maven-clean-install-build-action@v3.5.0
        - ikmdev/maven-post-build-action@v3.2.0
        - ikmdev/maven-semver-release-action@v2.7.0

- Updated the maven wrapper to 3.9.11

- Added some properties
        - <java.version>24</java.version>
        - <maven-dependency-analyzer.version>1.16.0</maven-dependency-analyzer.version>

- Added transitive dependency fix for maven-dependency-plugin

- Removed "--enable-preview" from codebase